### PR TITLE
[fix] Add bucket versioning and retention to buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "aws-sdk-route53",
  "aws-sdk-s3",
  "aws-sdk-sts",
+ "aws-smithy-http",
  "clap",
  "futures",
  "mime_guess",

--- a/src/cfn_template.yaml
+++ b/src/cfn_template.yaml
@@ -8,7 +8,10 @@ Parameters:
 
 Resources:
   #
-  # Our website bucket
+  # Our website bucket. A single older version
+  # of each file will be kept, and any older
+  # versions will be deleted permanently after
+  # 30 days.
   #
   WebsiteBucket:
     Type: AWS::S3::Bucket
@@ -17,6 +20,13 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: "Enabled"
+      LifecycleConfiguration:
+        Rules:
+          - NoncurrentVersionExpiration:
+              NewerNoncurrentVersions: 1
+              NoncurrentDays: 30
+            Id: NoncurrentVersionExpiry
+            Status: Enabled
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -110,12 +120,25 @@ Resources:
           SslSupportMethod: sni-only
 
   #
-  # The access logging bucket for our cloudfront distribution
+  # The access logging bucket for our cloudfront distribution. Logs
+  # will be cleaned up after 90 days and non-ccurrent versions will
+  # be cleaned up after 30.
   #
   LoggingBucket:
     Type: AWS::S3::Bucket
     Properties:
       AccessControl: LogDeliveryWrite
+      VersioningConfiguration:
+        Status: "Enabled"
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 90
+            Status: Enabled
+            Id: ExpireLogsAfter90Days
+          - NoncurrentVersionExpiration:
+              NoncurrentDays: 30
+            Status: Enabled
+            Id: ExpireNoncurrentVersions
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/src/cfn_template.yaml
+++ b/src/cfn_template.yaml
@@ -15,6 +15,8 @@ Resources:
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
     Properties:
+      VersioningConfiguration:
+        Status: "Enabled"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
The bucket containing the website assets should be versioned. This will allow users who accidentally modify or delete content in a way they hadn't intended to recover it. 

The bucket containing logs should retain logs for 90 days before deleting them, and retain a single noncurrent version for 30 days otherwise. This will keep the logs from growing forever, while protecting against accidental deletion.